### PR TITLE
When dist filename is "-", means that is STDOUT.

### DIFF
--- a/cmd/internal/cp/cp.go
+++ b/cmd/internal/cp/cp.go
@@ -387,10 +387,11 @@ func (c *client) s3stdout(bucket, key string) error {
 		return err
 	}
 	body := res.GetObjectOutput.Body
+	defer body.Close()
 	if _, err := io.Copy(os.Stdout, body); err != nil {
 		return err
 	}
-	return body.Close()
+	return nil
 }
 
 func (c *client) s3local(src, dist string) error {


### PR DESCRIPTION
Hi. This PR changes cp sub-command behavior.

`s3cli-mini cp src -` becomes output to STDOUT from src when dist filename is "-".

This behavior is the same with aws-cli.