### PR TITLE
fix multipart upload error

### DIFF
--- a/cmd/internal/cp/cp_test.go
+++ b/cmd/internal/cp/cp_test.go
@@ -85,6 +85,73 @@ func TestCP_Upload(t *testing.T) {
 	}
 }
 
+func TestCP_Upload_Multipart(t *testing.T) {
+	testutils.SkipIfUnitTest(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := config.NewS3Client()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketName, err := testutils.CreateTemporaryBucket(ctx, svc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testutils.DeleteBucket(context.Background(), svc, bucketName)
+
+	// prepare a test file
+	content := bytes.Repeat([]byte("temporary file's content"), 1024*1024)
+	dir, err := ioutil.TempDir("", "s3cli-mini")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	filename := filepath.Join(dir, "tmpfile")
+	if err := ioutil.WriteFile(filename, content, 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	// test
+	cmd := &cobra.Command{}
+	Run(cmd, []string{filename, "s3://" + bucketName + "/tmpfile.html"})
+
+	resp, err := svc.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("tmpfile.html"),
+	}).Send(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if string(body) != string(content) {
+		t.Errorf("want %s, got %s", string(content), string(body))
+	}
+	if aws.StringValue(resp.ContentType) != "text/html; charset=utf-8" {
+		t.Errorf("unexpected content-type: want %s, got %s", "text/html; charset-utf-8", aws.StringValue(resp.ContentType))
+	}
+
+	// check acl
+	retACL, err := svc.GetObjectAclRequest(&s3.GetObjectAclInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String("tmpfile.html"),
+	}).Send(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, g := range retACL.Grants {
+		if g.Grantee.Type != s3.TypeCanonicalUser {
+			t.Errorf("unexpected grantee type, want %s, got %s", s3.TypeCanonicalUser, g.Grantee.Type)
+		}
+	}
+}
+
 func TestCP_Upload_KeyOmitted(t *testing.T) {
 	testutils.SkipIfUnitTest(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/cmd/internal/cp/upload.go
+++ b/cmd/internal/cp/upload.go
@@ -252,6 +252,7 @@ func (u *uploader) nextReader() (io.ReadSeeker, int64, error) {
 				err = io.EOF
 			}
 			reader := io.NewSectionReader(r, u.readerPos, n)
+			u.readerPos += n
 			return reader, n, err
 		}
 	}


### PR DESCRIPTION
uploading large files fails. this pull request will fix it.

```
Upload /home/runner/work/_temp/redis-bin.tar.gz to s3://shogo82148-actions-setup-redis/v1.2.0/redis-5.0.9-linux-x64.tar.gz
SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
	status code: 403, request id: FFD581814B21D996, host id: 9qDawzT/Q3nzIkhu9dQ6O6R6fZ/KAFZ1f1QyUXacz6FcRDdAsK+EqemA1N/KaFqaLcl5+KwraRU=
Upload error:  context canceled
```