### PR TITLE
remove cache step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,6 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - run: go mod download
       - name: Configure AWS Credentials
         uses: fuller-inc/actions-aws-assume-role@v1


### PR DESCRIPTION
actions/setup-go@v5 cache dependencies automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed caching step from the continuous integration workflow to streamline testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->