### PR TITLE
fix deprecation notice of goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,40 +80,40 @@ blobs:
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
-    folder: amazonlinux/2/x86_64/s3cli-mini
+    directory: amazonlinux/2/x86_64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
-    folder: amazonlinux/2/aarch64/s3cli-mini
+    directory: amazonlinux/2/aarch64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
-    folder: amazonlinux/2023/x86_64/s3cli-mini
+    directory: amazonlinux/2023/x86_64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
-    folder: amazonlinux/2023/aarch64/s3cli-mini
+    directory: amazonlinux/2023/aarch64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
-    folder: centos/7/x86_64/s3cli-mini
+    directory: centos/7/x86_64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
-    folder: centos/7/aarch64/s3cli-mini
+    directory: centos/7/aarch64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
-    folder: almalinux/8/x86_64/s3cli-mini
+    directory: almalinux/8/x86_64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
-    folder: almalinux/8/aarch64/s3cli-mini
+    directory: almalinux/8/aarch64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-amd64]
-    folder: rockylinux/8/x86_64/s3cli-mini
+    directory: rockylinux/8/x86_64/s3cli-mini
   - provider: s3
     bucket: shogo82148-rpm-temporary
     ids: [package-arm64]
-    folder: rockylinux/8/aarch64/s3cli-mini
+    directory: rockylinux/8/aarch64/s3cli-mini


### PR DESCRIPTION
>  • DEPRECATED:  blobs.folder  should not be used anymore, check https://goreleaser.com/deprecations#blobsfolder for more info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated configuration terminology for better clarity across different operating systems and architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->