### PR TITLE
bump Go 1.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/s3cli-mini
 
-go 1.22.0
+go 1.23.4
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go version from 1.22.0 to 1.23.4.
	- Adjusted dependency versions without adding or removing any dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->